### PR TITLE
[Fix] requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,17 @@ __pycache__/
 data/
 postgres/
 staticfiles/
+
+# IDE
+.idea
+.vscode/
+
+# Vim
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+Session.vim
+Sessionx.vim

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ pytest==5.0.0
 pytest-cov==2.7.1
 pytest-django==3.5.1
 pytest-mock==1.10.4
+black==20.8b1
 
 # prod
 gunicorn==19.9.0


### PR DESCRIPTION
### Problem

I had trouble running the command `docker-compose run django black . --check`

![Captura de Tela 2020-08-29 às 14 30 11](https://user-images.githubusercontent.com/17599203/91642903-782a5e00-ea05-11ea-8ae4-35ff7417e31a.png)

I figured that it was because I don't have `black` locally installed in my computer + it was not in the `requirements.txt` file.

### Fixing

I added `black` to the requirements file and then rebuilt the project using `docker-compose build` and it started to work 🌟 

![Captura de Tela 2020-08-29 às 14 35 31](https://user-images.githubusercontent.com/17599203/91642966-d2c3ba00-ea05-11ea-98a8-1c990bd37290.png)

### This PR:
- [x] Adds IDE folders and Vim files to gitignore
- [x] Adds `black` ([last version](https://pypi.org/project/black/)) to requirements 