### PR TITLE
Adiciona Compose de criação de ambiente de staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 .coverage
 .env
+.env.staging
 .ipynb_checkpoints
 .pytest_cache/
 .python-version

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 .coverage
 .env
+.env.prod
 .env.staging
 .ipynb_checkpoints
 .pytest_cache/

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
       - redis
     env_file:
-      - .env
+      - .env.prod
     ports:
       - "8001:8001"
     command: ["gunicorn", "perfil.wsgi:application", "--reload", "--bind", "0.0.0.0:8001", "--workers", "1", "--log-level", "INFO", "--timeout", "300"]

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,18 @@
+version: '3' 
+services: 
+ 
+  django-staging: 
+    build: 
+      context: . 
+    depends_on: 
+      - redis-staging 
+    env_file: 
+      - .env.staging 
+    ports: 
+      - "8002:8001" 
+    command: ["gunicorn", "perfil.wsgi:application", "--reload", "--bind", "0.0.0.0:8001", "--workers", "1", "--log-level", "INFO", "--timeout", "300"] 
+ 
+  redis-staging: 
+    image: redis:4.0.11-alpine 
+    ports: 
+      - "6380:6379" 


### PR DESCRIPTION
Ambiente de staging fica configurado de forma que pode ser executado até
na mesma máquina. Funciona de forma idêntica ao ambiente de produção,
diferenciando-se apenas pelas portas, nomes dos serviços e variáveis de
ambiente.

Closes #199
