### PR TITLE
Correções realizadas para atualizar dados antes das eleições de 2022

### DIFF
--- a/perfil/core/management/commands/load_income_statements.py
+++ b/perfil/core/management/commands/load_income_statements.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
             return
 
         return ElectionIncomeStatement(
-            date=line["data"],
+            date=line["data"] or None,
             year=line["ano"],
             value=line["valor"],
             accountant_sequential=line["numero_sequencial"],

--- a/perfil/core/views.py
+++ b/perfil/core/views.py
@@ -199,17 +199,17 @@ class CandidateEconomicBonds:
                     "value": float(statement.value),
                     "donor_name": statement.donor_name,
                     "donor_taxpayer_id": statement.donor_taxpayer_id,
-                    "donor_company_name": statement.additional_income_information.get(
+                    "donor_company_name": statement.donor_company_information.get(
                         "nome_empresa"
                     ),
                     "donor_company_cnpj": CandidateEconomicBonds.build_company_cnpj(
-                        statement.additional_income_information
+                        statement.donor_company_information
                     ),
                     "donor_economic_sector_code": str(
-                        statement.additional_income_information.get("cnae_principal")
+                        statement.donor_company_information.get("cnae_principal")
                         or statement.donor_economic_sector_code
                     ),
-                    "donor_secondary_sector_codes": statement.additional_income_information.get(
+                    "donor_secondary_sector_codes": statement.donor_company_information.get(
                         "cnae_secundaria"
                     ),
                 }

--- a/populate_company_info.sql
+++ b/populate_company_info.sql
@@ -91,8 +91,14 @@ CREATE OR REPLACE FUNCTION clean_text(text) RETURNS text
     RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION format_date(text) RETURNS date
-    AS $$ select TO_DATE($1,'YYYYMMDD'); $$
-    LANGUAGE SQL
+    AS $$
+      BEGIN
+        RETURN TO_DATE($1,'YYYYMMDD');
+      EXCEPTION
+        WHEN others THEN RETURN NULL;
+      END;
+    $$
+    LANGUAGE plpgsql
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;
 

--- a/populate_company_info.sql
+++ b/populate_company_info.sql
@@ -147,7 +147,7 @@ SELECT
     etabelecimento.cnpj_raiz,
     etabelecimento.cnpj_ordem,
     etabelecimento.cnpj_dv,
-    etabelecimento.nome_fantasia as nome_empresa,
+    COALESCE(etabelecimento.nome_fantasia, empresa.razao_social) as nome_empresa,
     etabelecimento.cnae_principal,
     etabelecimento.cnae_secundaria,
     format_date(etabelecimento.data_inicio_atividade) as data_inicio_atividade,
@@ -159,6 +159,12 @@ SELECT
 FROM estabelecimento_temp as etabelecimento
 LEFT JOIN (
     SELECT
+        empresa_temp.cnpj_raiz,
+        empresa_temp.razao_social
+        FROM empresa_temp
+) as empresa ON empresa.cnpj_raiz = etabelecimento.cnpj_raiz
+LEFT JOIN (
+    SELECT
         socio.cnpj_raiz,
         socio.nome as nome_socio,
         socio.cpf_cnpj as cpf_socio,
@@ -166,17 +172,17 @@ LEFT JOIN (
     FROM socio_temp as socio WHERE socio.codigo_identificador = 2 AND socio.cpf_cnpj != '***000000**'
     UNION
     select
-        empresa.cnpj_raiz,
-        empresa.nome_socio,
-        empresa.cpf as cpf_socio,
+        empresa_cpf.cnpj_raiz,
+        empresa_cpf.nome_socio,
+        empresa_cpf.cpf as cpf_socio,
         null as data_entrada_sociedade
     FROM
         (select
              substring(empresa_temp.razao_social from '[0-9]*$') as cpf,
              substring(empresa_temp.razao_social from '\D*') as nome_socio,
              *
-         FROM empresa_temp) as empresa
-    WHERE (empresa.cpf = '') IS NOT TRUE
+         FROM empresa_temp) as empresa_cpf
+    WHERE (empresa_cpf.cpf = '') IS NOT TRUE
 ) as associados ON associados.cnpj_raiz = etabelecimento.cnpj_raiz;
 
 -- -----------------------

--- a/populate_company_info.sql
+++ b/populate_company_info.sql
@@ -44,7 +44,7 @@ CREATE TABLE "estabelecimento_temp" (
     "numero" TEXT,
     "complemento" TEXT,
     "bairro" TEXT,
-    "cep" REAL,
+    "cep" TEXT,
     "uf" TEXT,
     "codigo_municipio" INTEGER,
     "ddd_1" CHAR(4),
@@ -134,7 +134,7 @@ CREATE TABLE "empresas_socios_temp" (
     "data_inicio_atividade" DATE,
     "uf" CHAR(4),
     "nome_socio" TEXT,
-    "cpf_socio" CHAR(14),
+    "cpf_socio" TEXT,
     "data_entrada_sociedade" DATE,
     "socio_merge_uuid" uuid
 );


### PR DESCRIPTION
@arielbello havia separado algumas correções que tive que fazer para terminar de atualizar os dados mês passado e notei que não havia subido elas pro repositório ainda :/ A maioria tem a ver com dados da RFB, que foi a última etapa da atualização.

- Exclui ano do histórico de bens do candidato antes de atualizá-lo
- Transforma datas de receitas com formato errado em NULL
- Corrige acesso a variável de candidato em view de vínculos econômicos
- Desativa limite de número de caracteres em campos da base da RFB
- Adiciona razão social como fallback de nome de empresa
