### PR TITLE
Corrige comando load_assets para update do banco

### DIFF
--- a/perfil/core/management/commands/__init__.py
+++ b/perfil/core/management/commands/__init__.py
@@ -107,7 +107,7 @@ def get_candidate(year, state, sequential):
     if len(candidates) == 1:  # yay, there's only match!
         return candidates[0]
 
-    if len(candidates) == 2:  # probably it's the same person in the 2nd round
+    if len(candidates) == 2 and candidates[0].round != candidates[1].round:
         for candidate in candidates:
             if candidate.round == 1:
                 return candidate


### PR DESCRIPTION
O comando `load_assets` é usado para criar o banco do zero assim como para fazer update de novos dados. No caso de update, o comando não limpava o campo `asset_history` dos políticos, permitindo entradas duplicadas neste campo.

fixes #194 