### PR TITLE
Adiciona volumes no docker-compose de produção e staging

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,6 +10,8 @@ services:
       - .env.prod
     ports:
       - "8001:8001"
+    volumes:
+      - ./perfil:/code/perfil
     command: ["gunicorn", "perfil.wsgi:application", "--reload", "--bind", "0.0.0.0:8001", "--workers", "1", "--log-level", "INFO", "--timeout", "300"]
 
   redis:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -9,7 +9,10 @@ services:
     env_file: 
       - .env.staging 
     ports: 
-      - "8002:8001" 
+      - "8002:8001"
+    volumes:
+      - ./perfil:/code/perfil
+      - ./data:/mnt/data
     command: ["gunicorn", "perfil.wsgi:application", "--reload", "--bind", "0.0.0.0:8001", "--workers", "1", "--log-level", "INFO", "--timeout", "300"] 
  
   redis-staging: 


### PR DESCRIPTION
Adiciona volumes no `docker-compose.prod.yml` e `docker-compose.staging.yml` para permitir hot-reload e para poder rodar os comandos de atualização do banco no ambiente de staging.