### PR TITLE
Adiciona campo politician_id em CandidateListResource e CandidateDetailResource

### DIFF
--- a/perfil/core/views.py
+++ b/perfil/core/views.py
@@ -25,6 +25,7 @@ class CandidateListResource(DjangoResource):
     preparer = FieldsPreparer(
         fields={
             "id": "id",
+            "politician_id": "politician_id",
             "name": "ballot_name",
             "party": "party.abbreviation",
             "state": "state",
@@ -75,6 +76,7 @@ class CandidateDetailResource(DjangoResource):
     preparer = FieldsPreparer(
         fields={
             "id": "id",
+            "politician_id": "politician_id",
             "name": "name",
             "image": "image",
             "ballot_name": "ballot_name",


### PR DESCRIPTION
## Contexto
Os datasets de candidatos possuem mais de uma entrada para a mesma pessoa dependendo do `status`, por exemplo, pode se ter `CADASTRADO` e `APTO` para um mesmo candidato (a candidatura é primeiro cadastrada e o candidato se torna apto a concorrer depois que sua candidatura é julgada pela justiça eleitoral). No caso de duas candidaturas, serão criados dois registros com `ids` e `sequentials` diferentes.
## Solução
Retornar o campo `politician_id` que é o mesmo para candidaturas diferentes que representam a mesma pessoa (político). Com isso se torna possível agrupar diferentes candidaturas de um mesmo político. 