### PR TITLE
Corrige cálculo de medianas

### DIFF
--- a/perfil/core/management/commands/pre_calculate_stats.py
+++ b/perfil/core/management/commands/pre_calculate_stats.py
@@ -23,13 +23,34 @@ class Command(BaseCommand):
     def _get_assets_median_per_year() -> dict:
         sql = f"""
             SELECT
-                core_candidate.year,
-                array_agg(core_asset.value) as assets_values
-            FROM core_asset
-            INNER JOIN core_candidate
-            ON core_candidate.id = core_asset.candidate_id
-            WHERE core_candidate.round_result LIKE 'ELEIT%'
-            GROUP BY core_candidate.year;
+              candidate_result.year,
+              array_agg(assets_per_year_per_candidate.asset_values_sum) as assets_sum_per_candidate
+            FROM core_candidate as candidate_result
+            INNER JOIN (
+              SELECT
+                candidate_first_entry.year,
+                candidate_first_entry.id,
+                candidate_first_entry.sequential,
+                candidate_first_entry.voter_id,
+                sum(core_asset.value) as asset_values_sum
+              FROM
+                core_asset
+              LEFT JOIN core_candidate as candidate_first_entry
+              ON candidate_first_entry.id = core_asset.candidate_id
+              GROUP BY
+                candidate_first_entry.year,
+                candidate_first_entry.id,
+                candidate_first_entry.sequential,
+                candidate_first_entry.voter_id
+            ) as assets_per_year_per_candidate
+            ON
+              (candidate_result.sequential = assets_per_year_per_candidate.sequential)
+              AND (candidate_result.voter_id = assets_per_year_per_candidate.voter_id)
+              AND (candidate_result.year = assets_per_year_per_candidate.year)
+            WHERE
+              candidate_result.round_result LIKE 'ELEIT%'
+            GROUP BY
+              candidate_result.year;
         """
         with connection.cursor() as cursor:
             cursor.execute(sql)


### PR DESCRIPTION
Cálculo de medianas anterior estava calculando a mediana de bens
individuais e não da soma de todos os bens de uma candidatura.
Fazendo com que a mediana ficasse muito abaixo do valor real.
